### PR TITLE
Implement a shaded jar for s2i to work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,30 @@
           <target>${maven.compiler.target}</target>
         </configuration>
       </plugin>
+      <!-- Create a shaded jar for s2i to work -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <!-- Run shade goal on package phase -->
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                 <!--add Main-Class to manifest file-->
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>com.redhat.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
     </plugins>
   </build>

--- a/src/main/java/com/redhat/constants/Constants.java
+++ b/src/main/java/com/redhat/constants/Constants.java
@@ -2,12 +2,11 @@ package com.redhat.constants;
 
 public class Constants {
     public static final String CREDENTIALS_PATH_ENV_PROPERTY = "GOOGLE_APPLICATION_CREDENTIALS";
-    public static final String PROJECT_ID = "pub-sup-project";
-    public static final String SUBSCRIPTION_ID = "acrosub";
+    public static final String PROJECT_ID = System.getenv("PROJECT_ID");
+    public static final String SUBSCRIPTION_ID = System.getenv("SUBSCRIPTION_ID");
     public static final String HANGOUTS_CHAT_API_SCOPE = "https://www.googleapis.com/auth/chat.bot";
 
     // Response templates
     public static final String RESPONSE_URL_TEMPLATE = "https://chat.googleapis.com/v1/__SPACE_ID__/messages";
     public static final String ADDED_RESPONSE = "Thank you for adding me! Send `@AcroBot help` for more information about me.";
-
 }


### PR DESCRIPTION
Tested to work with OpenShift's s2i. OpenShift requires a fat jar; I have shaded the dependencies and my code into one jar so that it's not necessary to create a container image. It is possible we'll create a container image in the future in any case, but for now, this is suitable.