### PR TITLE
Provide functionality to update and remove explanations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of acronyms within the company.
 
 Acrobot is a simple application, using:
 
-* Java
+* Java (tested against OpenJDK 1.8 and OpenJDK 11)
 * Hibernate
 * MySQL
 * Kubernetes/OpenShift for deployment #todo OCP template

--- a/src/main/java/com/redhat/constants/Constants.java
+++ b/src/main/java/com/redhat/constants/Constants.java
@@ -18,6 +18,7 @@ public class Constants {
     public static final String EXPLANATION_UPDATED = "Explanation updated. Thank you!";
     public static final String EXPLANATION_REMOVED = "Explanation removed. Thank you!";
     public static final String EXPLANATION_NOT_FOUND = "No such explanation with given Acronym. Are you sure the acronym is correct?";
+    public static final String ACRONYM_NOT_FOUND = "No such acronym found.";
 
     public static final String HELP_TEXT = "You are interacting with Acrobot. \n\n" +
             "Actions:\n" +

--- a/src/main/java/com/redhat/constants/Constants.java
+++ b/src/main/java/com/redhat/constants/Constants.java
@@ -23,8 +23,11 @@ public class Constants {
             "Actions:\n" +
             "*Get an acronym explanation:* `@Acrobot acronym` \n" +
             "*Insert an acronym:* `@Acrobot !acronym=explanation` \n" +
-            "You can update an already existing acronym the same way as inserting. \n" +
-            "All of the actions work in a direct message without tagging @Acrobot. \n" +
+            "*Change old explanation to a new one:* `@Acrobot !acronym=old explanation => new explanation` \n" +
+            "*Delete old explanation: `@Acrobot !acronym = old explanation =>` \n" +
+            "You can add an explanation to an already existing acronym the same way as inserting. \n" +
+            "All of the actions work in a direct message without tagging `@Acrobot`. Whitespaces shouldn't matter," +
+            "and you can input acronym in both lower- and uppercase; it will be matched regardless of the capitalisation. \n\n" +
             "Acrobot is implemented by Marek Czernek. You can find documentation and file issues or suggest improvements at " +
             "https://github.com/m-czernek/acrobot";
 }

--- a/src/main/java/com/redhat/constants/Constants.java
+++ b/src/main/java/com/redhat/constants/Constants.java
@@ -14,6 +14,11 @@ public class Constants {
             " to save an explanation, or only $acronym to get an explanation";
     public static final String ACRONYM_SAVED = "Thank you, I have saved your acronym.";
     public static final String ACRONYM_UPDATED = "Thank you, I have updated the acronym";
+    public static final String INSUFFICIENT_PRIVILEGES = "You cannot update acronyms that you did not save. Aborting!";
+    public static final String EXPLANATION_UPDATED = "Explanation updated. Thank you!";
+    public static final String EXPLANATION_REMOVED = "Explanation removed. Thank you!";
+    public static final String EXPLANATION_NOT_FOUND = "No such explanation with given Acronym. Are you sure the acronym is correct?";
+
     public static final String HELP_TEXT = "You are interacting with Acrobot. \n\n" +
             "Actions:\n" +
             "*Get an acronym explanation:* `@Acrobot acronym` \n" +

--- a/src/main/java/com/redhat/entities/Explanation.java
+++ b/src/main/java/com/redhat/entities/Explanation.java
@@ -21,7 +21,7 @@ public class Explanation implements Serializable {
     private String explanation;
 
     @ManyToOne
-    @JoinColumn(name="acronym_id", nullable=false)
+    @JoinColumn(name="acronym_id")
     private Acronym acronym;
 
     // A flag for manual checks of explanations

--- a/src/main/java/com/redhat/messages/AdministrativeMessageHelper.java
+++ b/src/main/java/com/redhat/messages/AdministrativeMessageHelper.java
@@ -4,7 +4,7 @@ import com.redhat.persistence.PersistenceManager;
 
 public class AdministrativeMessageHelper {
 
-    static String handleAdminMessage(String msg) {
+    public static String handleAdminMessage(String msg) {
         if(msg.toLowerCase().contains("disconnect")) {
             PersistenceManager.INSTANCE.close();
             return "Disconnected from database";

--- a/src/main/java/com/redhat/messages/MessageHelper.java
+++ b/src/main/java/com/redhat/messages/MessageHelper.java
@@ -39,7 +39,7 @@ public class MessageHelper {
             }
 
             if(message.contains("=>")) {
-                resp = updateAcronymOrRemoveExplanation(message, authorEmail);
+                resp = updateOrRemoveExplanation(message, authorEmail);
             } else {
                 resp = saveOrMergeAcronym(message, authorEmail);
             }
@@ -52,7 +52,7 @@ public class MessageHelper {
         return resp;
     }
 
-    private String updateAcronymOrRemoveExplanation(String message, String authorEmail) {
+    private String updateOrRemoveExplanation(String message, String authorEmail) {
         String resp;
         String[] acronymExplanationsArray = splitMessageToSaveAndTrim(message);
 

--- a/src/main/java/com/redhat/messages/MessageHelper.java
+++ b/src/main/java/com/redhat/messages/MessageHelper.java
@@ -111,15 +111,14 @@ public class MessageHelper {
     }
 
     private String[] splitMessageToSaveAndTrim(String message) {
-        String[] res = message.split("=", 2);
-        trimArray(res);
-        return res;
+        return trimArray(message.split("=", 2));
     }
 
-    private void trimArray(String[] array) {
+    private String[] trimArray(String[] array) {
         for(int i = 0; i < array.length; i++) {
             array[i] = array[i].trim();
         }
+        return array;
     }
 
     private void mergeAcronym(Acronym acronym, String explanation, String authorEmail) {

--- a/src/main/java/com/redhat/messages/MessageHelper.java
+++ b/src/main/java/com/redhat/messages/MessageHelper.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.redhat.constants.Constants;
 import com.redhat.entities.Acronym;
 import com.redhat.entities.Explanation;
-import com.redhat.persistence.AcronymDAL;
+import com.redhat.persistence.AcronymExplanationDal;
 
 import java.util.HashSet;
 import java.util.List;
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public class MessageHelper {
 
-    private AcronymDAL acronymDal = new AcronymDAL();
+    private AcronymExplanationDal acronymExplanationDal = new AcronymExplanationDal();
 
     public String handleMessageAction(JsonNode eventJson) {
         String resp;
@@ -56,7 +56,7 @@ public class MessageHelper {
         String resp;
         String[] acronymExplanationsArray = splitMessageToSaveAndTrim(message);
 
-        List<Acronym> acronyms = acronymDal.getAcronymsByName(acronymExplanationsArray[0]);
+        List<Acronym> acronyms = acronymExplanationDal.getAcronymsByName(acronymExplanationsArray[0]);
         if(acronyms.isEmpty()) {
             return "No such acronym found.";
         }
@@ -77,20 +77,20 @@ public class MessageHelper {
 
         if(trimmedOldNewExplanation.length == 1) {
             a.getExplanations().remove(e);
-            acronymDal.deleteExplanation(e);
+            acronymExplanationDal.deleteExplanation(e);
             resp = "Removed explanation";
         } else {
             e.setExplanation(trimmedOldNewExplanation[1]);
             resp = "Updated explanation";
         }
-        acronymDal.updateAcronym(a);
+        acronymExplanationDal.updateAcronym(a);
         return resp;
     }
 
     private String saveOrMergeAcronym(String message, String authorEmail) {
         String resp;
         String[] toSave = splitMessageToSaveAndTrim(message);
-        List<Acronym> list = acronymDal.getAcronymsByName(toSave[0]);
+        List<Acronym> list = acronymExplanationDal.getAcronymsByName(toSave[0]);
         if(list.isEmpty()) {
             saveAcronym(toSave, authorEmail);
             resp = Constants.ACRONYM_SAVED;
@@ -122,12 +122,12 @@ public class MessageHelper {
         e.setAcronym(acronym);
         e.setAuthorEmail(authorEmail);
         acronym.getExplanations().add(e);
-        acronymDal.updateAcronym(acronym);
+        acronymExplanationDal.updateAcronym(acronym);
     }
 
     private String getAcronymAsString(String message) {
         String resp = "";
-        for(Acronym a : acronymDal.getAcronymsByName(message)) {
+        for(Acronym a : acronymExplanationDal.getAcronymsByName(message)) {
             for(Explanation e : a.getExplanations()) {
                 resp += e.getExplanation() + "\n";
             }
@@ -146,6 +146,6 @@ public class MessageHelper {
         Set<Explanation> set = new HashSet<>();
         set.add(e);
         a.setExplanations(set);
-        acronymDal.saveAcronym(a);
+        acronymExplanationDal.saveAcronym(a);
     }
 }

--- a/src/main/java/com/redhat/messages/MessageHelper.java
+++ b/src/main/java/com/redhat/messages/MessageHelper.java
@@ -62,12 +62,12 @@ public class MessageHelper {
         }
 
         String[] oldNewExplanation = acronymExplanationsArray[1].split("=>");
-        String[] trimmedOldNewExplanation = trimArray(oldNewExplanation);
+        trimArray(oldNewExplanation);
 
         Acronym a = acronyms.get(0);
         Explanation e = a.getExplanations()
                 .stream()
-                .filter(explanation -> explanation.getExplanation().equals(trimmedOldNewExplanation[0]))
+                .filter(explanation -> explanation.getExplanation().equals(oldNewExplanation[0]))
                 .findFirst()
                 .orElse(null);
 
@@ -79,12 +79,12 @@ public class MessageHelper {
             return "Insufficient privileges";
         }
 
-        if(trimmedOldNewExplanation.length == 1) {
+        if(oldNewExplanation.length == 1) {
             a.getExplanations().remove(e);
             acronymExplanationDal.deleteExplanation(e);
             resp = "Removed explanation";
         } else {
-            e.setExplanation(trimmedOldNewExplanation[1]);
+            e.setExplanation(oldNewExplanation[1]);
             resp = "Updated explanation";
         }
         acronymExplanationDal.updateAcronym(a);
@@ -111,14 +111,15 @@ public class MessageHelper {
     }
 
     private String[] splitMessageToSaveAndTrim(String message) {
-        return trimArray(message.split("=", 2));
+        String[] res = message.split("=", 2);
+        trimArray(res);
+        return res;
     }
 
-    private String[] trimArray(String[] array) {
+    private void trimArray(String[] array) {
         for(int i = 0; i < array.length; i++) {
             array[i] = array[i].trim();
         }
-        return array;
     }
 
     private void mergeAcronym(Acronym acronym, String explanation, String authorEmail) {

--- a/src/main/java/com/redhat/messages/MessageHelper.java
+++ b/src/main/java/com/redhat/messages/MessageHelper.java
@@ -58,7 +58,7 @@ public class MessageHelper {
 
         List<Acronym> acronyms = acronymExplanationDal.getAcronymsByName(acronymExplanationsArray[0]);
         if(acronyms.isEmpty()) {
-            return "No such acronym found.";
+            return Constants.ACRONYM_NOT_FOUND;
         }
 
         String[] oldNewExplanation = acronymExplanationsArray[1].split("=>");
@@ -137,7 +137,7 @@ public class MessageHelper {
             }
         }
         if(resp.isEmpty()) {
-            resp = "No acronym " + message + " found.";
+            resp = Constants.ACRONYM_NOT_FOUND;
         }
         return resp;
     }

--- a/src/main/java/com/redhat/messages/MessageHelper.java
+++ b/src/main/java/com/redhat/messages/MessageHelper.java
@@ -69,7 +69,11 @@ public class MessageHelper {
                 .stream()
                 .filter(explanation -> explanation.getExplanation().equals(trimmedOldNewExplanation[0]))
                 .findFirst()
-                .get();
+                .orElse(null);
+
+        if(e == null) {
+            return "no such explanation";
+        }
 
         if(!e.getAuthorEmail().equals(authorEmail)) {
             return "Insufficient privileges";

--- a/src/main/java/com/redhat/messages/MessageHelper.java
+++ b/src/main/java/com/redhat/messages/MessageHelper.java
@@ -72,20 +72,20 @@ public class MessageHelper {
                 .orElse(null);
 
         if(e == null) {
-            return "no such explanation";
+            return Constants.EXPLANATION_NOT_FOUND;
         }
 
         if(!e.getAuthorEmail().equals(authorEmail)) {
-            return "Insufficient privileges";
+            return Constants.INSUFFICIENT_PRIVILEGES;
         }
 
         if(oldNewExplanation.length == 1) {
             a.getExplanations().remove(e);
             acronymExplanationDal.deleteExplanation(e);
-            resp = "Removed explanation";
+            resp = Constants.EXPLANATION_REMOVED;
         } else {
             e.setExplanation(oldNewExplanation[1]);
-            resp = "Updated explanation";
+            resp = Constants.EXPLANATION_UPDATED;
         }
         acronymExplanationDal.updateAcronym(a);
         return resp;

--- a/src/main/java/com/redhat/persistence/AcronymDAL.java
+++ b/src/main/java/com/redhat/persistence/AcronymDAL.java
@@ -1,6 +1,7 @@
 package com.redhat.persistence;
 
 import com.redhat.entities.Acronym;
+import com.redhat.entities.Explanation;
 
 import javax.persistence.EntityManager;
 import java.util.Collections;
@@ -54,6 +55,20 @@ public class AcronymDAL {
             em.getTransaction().rollback();
         }
         close();
+    }
+
+    public void deleteExplanation(Explanation explanation) {
+        init();
+        em.getTransaction().begin();
+        try {
+            explanation.setAcronym(null);
+            explanation = em.merge(explanation);
+            em.remove(explanation);
+            em.getTransaction().commit();
+        } catch (Exception e) {
+            e.printStackTrace();
+            em.getTransaction().rollback();
+        }
     }
 
     public void init() {

--- a/src/main/java/com/redhat/persistence/AcronymExplanationDal.java
+++ b/src/main/java/com/redhat/persistence/AcronymExplanationDal.java
@@ -7,11 +7,11 @@ import javax.persistence.EntityManager;
 import java.util.Collections;
 import java.util.List;
 
-public class AcronymDAL {
+public class AcronymExplanationDal {
 
     private EntityManager em;
 
-    public AcronymDAL() {
+    public AcronymExplanationDal() {
         init();
     }
 

--- a/src/test/java/com/redhat/DataAccessLayerTest.java
+++ b/src/test/java/com/redhat/DataAccessLayerTest.java
@@ -2,7 +2,7 @@ package com.redhat;
 
 import com.redhat.entities.Acronym;
 import com.redhat.entities.Explanation;
-import com.redhat.persistence.AcronymDAL;
+import com.redhat.persistence.AcronymExplanationDal;
 import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -12,7 +12,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class DataAccessLayerTest {
-    private AcronymDAL dal = new AcronymDAL();
+    private AcronymExplanationDal dal = new AcronymExplanationDal();
     private static final String ACRONYM_LOWERCASE_NAME = "foo";
     private static final String ACRONYM_UPPERCASE_NAME = "FOO";
     private static final String UPDATE_ACRONYM = "baz";

--- a/src/test/java/com/redhat/MessageHelperTest.java
+++ b/src/test/java/com/redhat/MessageHelperTest.java
@@ -97,13 +97,13 @@ public class MessageHelperTest {
                 .isEqualTo("Updated explanation");
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymLowercase()))
-                .contains("BAR3");
+                .isEqualTo("BAR2" + "\n");
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getDeleteAcronymExplanation()))
                 .contains("Removed explanation");
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymLowercase()))
-                .doesNotContain("BAR3");
+                .doesNotContain("BAR2");
     }
 
     /**
@@ -113,10 +113,16 @@ public class MessageHelperTest {
     public void updateDeleteFailTest() {
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getUpdateAcronymExplanationDifferentUser()))
+                .as("Updating acronym with different email address did not fail properly")
                 .isEqualTo("Insufficient privileges");
 
         Assertions
-                .assertThat(helper.handleMessageAction(JsonNodeHelper.getDeleteAcronymExplanationDifferentUser()))
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymLowercase()))
+                .contains(JsonNodeHelper.EXPLANATION);
+
+        Assertions
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getDeleteAcronymInitialExplanationDifferentUser()))
+                .as("Deleting acronym with different email address did not fail properly")
                 .isEqualTo("Insufficient privileges");
     }
 

--- a/src/test/java/com/redhat/MessageHelperTest.java
+++ b/src/test/java/com/redhat/MessageHelperTest.java
@@ -84,7 +84,7 @@ public class MessageHelperTest {
                 .isEqualTo(Constants.INCORRECT_FORMAT_FOR_SAVING_ACRONYM);
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getIncorrectAcronym()))
-                .contains("No acronym");
+                .isEqualTo(Constants.ACRONYM_NOT_FOUND);
     }
 
     /**
@@ -163,7 +163,7 @@ public class MessageHelperTest {
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getInitialAcronymLowercase()))
                 .as("An acronym with an empty explanation set should be evaluated as not found")
-                .contains("No acronym");
+                .isEqualTo(Constants.ACRONYM_NOT_FOUND);
 
         // Updating original acronym with a new explanation
         helper.handleMessageAction(JsonNodeHelper.updateInitialAcronym());

--- a/src/test/java/com/redhat/MessageHelperTest.java
+++ b/src/test/java/com/redhat/MessageHelperTest.java
@@ -50,11 +50,11 @@ public class MessageHelperTest {
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getAddAcronymRequest()))
                 .isEqualTo(Constants.ACRONYM_SAVED);
         Assertions
-                .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymLowercase()).trim())
-                .isEqualTo(JsonNodeHelper.EXPLANATION);
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymLowercase()))
+                .isEqualTo(JsonNodeHelper.EXPLANATION + "\n");
         Assertions
-                .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymUppercase()).trim())
-                .isEqualTo(JsonNodeHelper.EXPLANATION);
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymUppercase()))
+                .isEqualTo(JsonNodeHelper.EXPLANATION + "\n");
     }
 
     /**
@@ -87,5 +87,22 @@ public class MessageHelperTest {
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getIncorrectAcronym()))
                 .contains("No acronym");
+    }
+
+    @Test
+    public void updateOldExplanation() {
+        Assertions
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getUpdateAcronymExplanation()))
+                .isEqualTo("Updated explanation");
+        Assertions
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymLowercase()))
+                .contains("BAR3");
+        Assertions
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getDeleteAcronymExplanation()))
+                .contains("Removed explanation");
+
+        Assertions
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getAcronymLowercase()))
+                .doesNotContain("BAR3");
     }
 }

--- a/src/test/java/com/redhat/helpers/JsonNodeHelper.java
+++ b/src/test/java/com/redhat/helpers/JsonNodeHelper.java
@@ -19,6 +19,8 @@ public class JsonNodeHelper {
     private static String INCORRECT_ACRONYM = "ACRONYM";
     private static String INCORRECT_ACRONYM_SAVE = "!" + INCORRECT_ACRONYM + "  ";
     private static String INCORRECT_ACRONYM_SAVE_WITH_EQUALS = "! " + INCORRECT_ACRONYM + " =   ";
+    private static String UPDATE_OLD_EXPLANATION = "!FOO1=BAR1=>BAR3";
+    private static String DELETE_EXPLANATION = "!FOO1=BAR3=>";
 
     public static JsonNode getJsonNodeWithoutMessageArgumentText() {
         try {
@@ -56,6 +58,14 @@ public class JsonNodeHelper {
 
     public static JsonNode getIncorrectAcronymSaveWithEquals() {
         return alterArgumentText(INCORRECT_ACRONYM_SAVE_WITH_EQUALS);
+    }
+
+    public static JsonNode getUpdateAcronymExplanation() {
+        return alterArgumentText(UPDATE_OLD_EXPLANATION);
+    }
+
+    public static JsonNode getDeleteAcronymExplanation() {
+        return alterArgumentText(DELETE_EXPLANATION);
     }
 
     public static JsonNode getIncorrectAcronym() {

--- a/src/test/java/com/redhat/helpers/JsonNodeHelper.java
+++ b/src/test/java/com/redhat/helpers/JsonNodeHelper.java
@@ -9,20 +9,30 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 
 public class JsonNodeHelper {
-    private static ObjectMapper mapper = new ObjectMapper();
-    private static JsonFactory factory = mapper.getFactory();
-    private static String INITIAL_ACRONYM = "FOO1";
-    public static String EXPLANATION = "BAR1";
-    public static String EXPLANATION_UPDATE = "BAR2";
-    private static String UPDATE_ACRONYM = "! " + INITIAL_ACRONYM + " = " + EXPLANATION_UPDATE;
-    private static String INCORRECT_ACRONYM = "ACRONYM";
-    private static String INCORRECT_ACRONYM_SAVE = "!" + INCORRECT_ACRONYM + "  ";
-    private static String INCORRECT_ACRONYM_SAVE_WITH_EQUALS = "! " + INCORRECT_ACRONYM + " =   ";
-    private static String UPDATE_OLD_EXPLANATION = "!" + INITIAL_ACRONYM + "=" + EXPLANATION + "=>" + EXPLANATION_UPDATE;
-    private static String DELETE_EXPLANATION = "!" + INITIAL_ACRONYM + "="+ EXPLANATION_UPDATE + "=>";
-    private static String DELETE_ORIGINAL_EXPLANATION = "!" + INITIAL_ACRONYM + "="+ EXPLANATION + "=>";
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final JsonFactory factory = mapper.getFactory();
+    private static final String INITIAL_ACRONYM = "FOO1";
+    public static final String EXPLANATION = "BAR1";
+    public static final String EXPLANATION_UPDATE = "BAR2";
 
-    private static String SETUP_DB_ACRONYM = "! " +  INITIAL_ACRONYM + "  =  " + EXPLANATION;
+    // Incorrect inputs
+    private static final String INCORRECT_ACRONYM = "ACRONYM";
+    private static final String INCORRECT_ACRONYM_SAVE = "!" + INCORRECT_ACRONYM + "  ";
+    private static final String INCORRECT_ACRONYM_SAVE_WITH_EQUALS = "! " + INCORRECT_ACRONYM + " =   ";
+
+    // Correct update inputs
+    private static final String UPDATE_ACRONYM = "! " + INITIAL_ACRONYM + " = " + EXPLANATION_UPDATE;
+    private static final String UPDATE_OLD_EXPLANATION = "!" + INITIAL_ACRONYM + "  =   " + EXPLANATION + "=>" + EXPLANATION_UPDATE;
+
+    // Delete inputs
+    private static final String DELETE_EXPLANATION = "!" + INITIAL_ACRONYM + "   =    "+ EXPLANATION_UPDATE + "=>";
+    private static final String DELETE_ORIGINAL_EXPLANATION = "!" + INITIAL_ACRONYM + "    =    "+ EXPLANATION + "=>";
+
+    // Setup acronym
+    private static final String SETUP_DB_ACRONYM = "! " +  INITIAL_ACRONYM + "  =  " + EXPLANATION;
+
+    // Misc
+    private static final String NON_STANDARD_EMAIL = "rbecky@example.com";
 
     public static JsonNode getJsonNodeWithoutMessageArgumentText() {
         try {
@@ -42,15 +52,15 @@ public class JsonNodeHelper {
         return alterArgumentText(SETUP_DB_ACRONYM);
     }
 
-    public static JsonNode getAcronymLowercase() {
+    public static JsonNode getInitialAcronymLowercase() {
         return alterArgumentText(INITIAL_ACRONYM.toLowerCase());
     }
 
-    public static JsonNode getAcronymUppercase() {
+    public static JsonNode getInitialAcronymUppercase() {
         return alterArgumentText(INITIAL_ACRONYM);
     }
 
-    public static JsonNode getUpdateAcronym() {
+    public static JsonNode updateInitialAcronym() {
         return alterArgumentText(UPDATE_ACRONYM);
     }
 
@@ -62,24 +72,24 @@ public class JsonNodeHelper {
         return alterArgumentText(INCORRECT_ACRONYM_SAVE_WITH_EQUALS);
     }
 
-    public static JsonNode getUpdateAcronymExplanation() {
+    public static JsonNode updateAcronymExplanationSameEmail() {
         return alterArgumentText(UPDATE_OLD_EXPLANATION);
     }
 
-    public static JsonNode getDeleteAcronymExplanation() {
+    public static JsonNode deleteUpdatedAcronymExplanationSameEmail() {
         return alterArgumentText(DELETE_EXPLANATION);
     }
 
-    public static JsonNode getDeleteAcronymInitialExplanation() {
+    public static JsonNode deleteAcronymInitialExplanation() {
         return alterArgumentText(DELETE_ORIGINAL_EXPLANATION);
     }
 
     public static JsonNode getUpdateAcronymExplanationDifferentUser() {
-        return alterUser(getUpdateAcronymExplanation(), "rbecky@example.com");
+        return alterUser(updateAcronymExplanationSameEmail(), NON_STANDARD_EMAIL);
     }
 
     public static JsonNode getDeleteAcronymInitialExplanationDifferentUser() {
-        return alterUser(getDeleteAcronymInitialExplanation(), "rbecky@example.com");
+        return alterUser(deleteAcronymInitialExplanation(), NON_STANDARD_EMAIL);
     }
 
     public static JsonNode getIncorrectAcronym() {

--- a/src/test/java/com/redhat/helpers/JsonNodeHelper.java
+++ b/src/test/java/com/redhat/helpers/JsonNodeHelper.java
@@ -18,8 +18,9 @@ public class JsonNodeHelper {
     private static String INCORRECT_ACRONYM = "ACRONYM";
     private static String INCORRECT_ACRONYM_SAVE = "!" + INCORRECT_ACRONYM + "  ";
     private static String INCORRECT_ACRONYM_SAVE_WITH_EQUALS = "! " + INCORRECT_ACRONYM + " =   ";
-    private static String UPDATE_OLD_EXPLANATION = "!" + INITIAL_ACRONYM + "=" + EXPLANATION + "=>BAR3";
-    private static String DELETE_EXPLANATION = "!" + INITIAL_ACRONYM + "=BAR3=>";
+    private static String UPDATE_OLD_EXPLANATION = "!" + INITIAL_ACRONYM + "=" + EXPLANATION + "=>" + EXPLANATION_UPDATE;
+    private static String DELETE_EXPLANATION = "!" + INITIAL_ACRONYM + "="+ EXPLANATION_UPDATE + "=>";
+    private static String DELETE_ORIGINAL_EXPLANATION = "!" + INITIAL_ACRONYM + "="+ EXPLANATION + "=>";
 
     private static String SETUP_DB_ACRONYM = "! " +  INITIAL_ACRONYM + "  =  " + EXPLANATION;
 
@@ -69,12 +70,16 @@ public class JsonNodeHelper {
         return alterArgumentText(DELETE_EXPLANATION);
     }
 
+    public static JsonNode getDeleteAcronymInitialExplanation() {
+        return alterArgumentText(DELETE_ORIGINAL_EXPLANATION);
+    }
+
     public static JsonNode getUpdateAcronymExplanationDifferentUser() {
         return alterUser(getUpdateAcronymExplanation(), "rbecky@example.com");
     }
 
-    public static JsonNode getDeleteAcronymExplanationDifferentUser() {
-        return alterUser(getDeleteAcronymExplanation(), "rbecky@example.com");
+    public static JsonNode getDeleteAcronymInitialExplanationDifferentUser() {
+        return alterUser(getDeleteAcronymInitialExplanation(), "rbecky@example.com");
     }
 
     public static JsonNode getIncorrectAcronym() {

--- a/src/test/java/com/redhat/helpers/JsonNodeHelper.java
+++ b/src/test/java/com/redhat/helpers/JsonNodeHelper.java
@@ -11,16 +11,17 @@ import java.io.IOException;
 public class JsonNodeHelper {
     private static ObjectMapper mapper = new ObjectMapper();
     private static JsonFactory factory = mapper.getFactory();
-    private static String ACRONYM = "FOO1";
+    private static String INITIAL_ACRONYM = "FOO1";
     public static String EXPLANATION = "BAR1";
     public static String EXPLANATION_UPDATE = "BAR2";
-    private static String SAVE_ACRONYM = "!  " + ACRONYM + "  =  " + EXPLANATION;
-    private static String UPDATE_ACRONYM = "! " + ACRONYM + " = " + EXPLANATION_UPDATE;
+    private static String UPDATE_ACRONYM = "! " + INITIAL_ACRONYM + " = " + EXPLANATION_UPDATE;
     private static String INCORRECT_ACRONYM = "ACRONYM";
     private static String INCORRECT_ACRONYM_SAVE = "!" + INCORRECT_ACRONYM + "  ";
     private static String INCORRECT_ACRONYM_SAVE_WITH_EQUALS = "! " + INCORRECT_ACRONYM + " =   ";
-    private static String UPDATE_OLD_EXPLANATION = "!FOO1=BAR1=>BAR3";
-    private static String DELETE_EXPLANATION = "!FOO1=BAR3=>";
+    private static String UPDATE_OLD_EXPLANATION = "!" + INITIAL_ACRONYM + "=" + EXPLANATION + "=>BAR3";
+    private static String DELETE_EXPLANATION = "!" + INITIAL_ACRONYM + "=BAR3=>";
+
+    private static String SETUP_DB_ACRONYM = "! " +  INITIAL_ACRONYM + "  =  " + EXPLANATION;
 
     public static JsonNode getJsonNodeWithoutMessageArgumentText() {
         try {
@@ -36,16 +37,16 @@ public class JsonNodeHelper {
         return alterArgumentText("help");
     }
 
-    public static JsonNode getAddAcronymRequest() {
-        return alterArgumentText(SAVE_ACRONYM);
+    public static JsonNode getSetupDb() {
+        return alterArgumentText(SETUP_DB_ACRONYM);
     }
 
     public static JsonNode getAcronymLowercase() {
-        return alterArgumentText(ACRONYM.toLowerCase());
+        return alterArgumentText(INITIAL_ACRONYM.toLowerCase());
     }
 
     public static JsonNode getAcronymUppercase() {
-        return alterArgumentText(ACRONYM);
+        return alterArgumentText(INITIAL_ACRONYM);
     }
 
     public static JsonNode getUpdateAcronym() {
@@ -68,6 +69,14 @@ public class JsonNodeHelper {
         return alterArgumentText(DELETE_EXPLANATION);
     }
 
+    public static JsonNode getUpdateAcronymExplanationDifferentUser() {
+        return alterUser(getUpdateAcronymExplanation(), "rbecky@example.com");
+    }
+
+    public static JsonNode getDeleteAcronymExplanationDifferentUser() {
+        return alterUser(getDeleteAcronymExplanation(), "rbecky@example.com");
+    }
+
     public static JsonNode getIncorrectAcronym() {
         return alterArgumentText(INCORRECT_ACRONYM);
     }
@@ -75,9 +84,17 @@ public class JsonNodeHelper {
     private static ObjectNode alterArgumentText(String argumentTextString) {
         JsonNode node = JsonNodeHelper.getJsonNodeWithoutMessageArgumentText();
         ObjectNode nodeHelpText = ((ObjectNode) node);
-        ObjectNode message = (ObjectNode) nodeHelpText.get("message");
-        message.put("argumentText", argumentTextString);
-        nodeHelpText.set("message", message);
+        ObjectNode messageNode = (ObjectNode) nodeHelpText.get("message");
+        messageNode.put("argumentText", argumentTextString);
+        nodeHelpText.set("message", messageNode);
+        return nodeHelpText;
+    }
+
+    private static ObjectNode alterUser(JsonNode node, String user) {
+        ObjectNode nodeHelpText = ((ObjectNode) node);
+        ObjectNode userNode = (ObjectNode) nodeHelpText.get("user");
+        userNode.put("email", user);
+        nodeHelpText.set("user", userNode);
         return nodeHelpText;
     }
 

--- a/src/test/java/com/redhat/helpers/JsonNodeHelper.java
+++ b/src/test/java/com/redhat/helpers/JsonNodeHelper.java
@@ -11,9 +11,10 @@ import java.io.IOException;
 public class JsonNodeHelper {
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final JsonFactory factory = mapper.getFactory();
-    private static final String INITIAL_ACRONYM = "FOO1";
+    public static final String INITIAL_ACRONYM = "FOO1";
     public static final String EXPLANATION = "BAR1";
     public static final String EXPLANATION_UPDATE = "BAR2";
+    public static final String NON_EXISTENT_EXPLANATION = "BAR3";
 
     // Incorrect inputs
     private static final String INCORRECT_ACRONYM = "ACRONYM";
@@ -92,11 +93,15 @@ public class JsonNodeHelper {
         return alterUser(deleteAcronymInitialExplanation(), NON_STANDARD_EMAIL);
     }
 
+    public static JsonNode updateNonExistentExplanation() {
+        return alterArgumentText("!" + INITIAL_ACRONYM + "=" + NON_EXISTENT_EXPLANATION + "=>");
+    }
+
     public static JsonNode getIncorrectAcronym() {
         return alterArgumentText(INCORRECT_ACRONYM);
     }
 
-    private static ObjectNode alterArgumentText(String argumentTextString) {
+    public static ObjectNode alterArgumentText(String argumentTextString) {
         JsonNode node = JsonNodeHelper.getJsonNodeWithoutMessageArgumentText();
         ObjectNode nodeHelpText = ((ObjectNode) node);
         ObjectNode messageNode = (ObjectNode) nodeHelpText.get("message");


### PR DESCRIPTION
This PR implements RFE in #3 . Features:

1. Change old explanations into new with: `!acronym = Old Explanation => New Explanation`
2. Delete explanations with: `!acronym = Old Explanation =>`
3. Adds tests for both of the functionalities

If no objections are raised during the initial deployment, this PR will be merged. It closes/resolves #3 