### PR TITLE
Provide the user information about unsuccessful operations (exceptions)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - openjdk11
-  - openjdk8
 notifications:
   email: false
 install: /bin/true

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ database.
 
 Acrobot is a simple application, using:
 
-* Java (tested against OpenJDK 1.8 and OpenJDK 11)
+* Java (tested against OpenJDK 11)
 * Hibernate
 * MySQL
 * Kubernetes/OpenShift for deployment #todo OCP template

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ you created. If you are deploying Acrobot on Kubernetes/OpenShift, you will have
 1. export **JDBC_URL**, **JDBC_USER**, and **JDBC_PASSWORD** for the DB connection details.
 1. export **PROJECT_ID** and **SUBSCRIPTION_ID** which match your Google project and subscription created earlier.
 
+## Testing
+
+Acrobot contains unit tests with an in-memory H2 database. You should execute all tests before pushing new code.
+You can execute tests by issuing: `mvn clean test`. To execute a particular test, you can specify the `test`
+parameter in the format of `ClassName#TestName`, for example:
+ 
+ `mvn clean test -Dtest=MessageHelperTest#exceptionPropagationTest`
+
+All new features should have tests.
+
 ## Credits
 
 Author: Marek Czernek.

--- a/src/main/java/com/redhat/constants/Constants.java
+++ b/src/main/java/com/redhat/constants/Constants.java
@@ -15,7 +15,6 @@ public class Constants {
     public static final String ACRONYM_SAVED = "Thank you, I have saved your acronym.";
     public static final String ACRONYM_UPDATED = "Thank you, I have updated the acronym";
     public static final String INSUFFICIENT_PRIVILEGES = "You cannot update acronyms that you did not save. Aborting!";
-    public static final String EXPLANATION_UPDATED = "Explanation updated. Thank you!";
     public static final String EXPLANATION_REMOVED = "Explanation removed. Thank you!";
     public static final String EXPLANATION_NOT_FOUND = "No such explanation with given Acronym. Are you sure the acronym is correct?";
     public static final String ACRONYM_NOT_FOUND = "No such acronym found. Add it using the syntax `! acronym = explanation` (queries are case-insensitive), " + 

--- a/src/main/java/com/redhat/messages/MessageHelper.java
+++ b/src/main/java/com/redhat/messages/MessageHelper.java
@@ -81,13 +81,11 @@ public class MessageHelper {
 
         if(oldNewExplanation.length == 1) {
             a.getExplanations().remove(e);
-            acronymExplanationDal.deleteExplanation(e);
-            resp = Constants.EXPLANATION_REMOVED;
+            resp = acronymExplanationDal.deleteExplanation(e);
         } else {
             e.setExplanation(oldNewExplanation[1]);
-            resp = Constants.EXPLANATION_UPDATED;
+            resp = acronymExplanationDal.updateAcronym(a);
         }
-        acronymExplanationDal.updateAcronym(a);
         return resp;
     }
 
@@ -96,12 +94,10 @@ public class MessageHelper {
         String[] toSave = splitMessageToSaveAndTrim(message);
         List<Acronym> list = acronymExplanationDal.getAcronymsByName(toSave[0]);
         if(list.isEmpty()) {
-            saveAcronym(toSave, authorEmail);
-            resp = Constants.ACRONYM_SAVED;
+            resp = saveAcronym(toSave, authorEmail);
         }
         else {
-            mergeAcronym(list.get(0), toSave[1], authorEmail);
-            resp = Constants.ACRONYM_UPDATED;
+            resp = mergeAcronym(list.get(0), toSave[1], authorEmail);
         }
         return resp;
     }
@@ -121,12 +117,12 @@ public class MessageHelper {
         return array;
     }
 
-    private void mergeAcronym(Acronym acronym, String explanation, String authorEmail) {
+    private String mergeAcronym(Acronym acronym, String explanation, String authorEmail) {
         Explanation e = new Explanation(explanation);
         e.setAcronym(acronym);
         e.setAuthorEmail(authorEmail);
         acronym.getExplanations().add(e);
-        acronymExplanationDal.updateAcronym(acronym);
+        return acronymExplanationDal.updateAcronym(acronym);
     }
 
     private String getAcronymAsString(String message) {
@@ -142,7 +138,7 @@ public class MessageHelper {
         return resp;
     }
 
-    private void saveAcronym(String[] toSave, String authorEmail) {
+    private String saveAcronym(String[] toSave, String authorEmail) {
         Explanation e = new Explanation(toSave[1]);
         e.setAuthorEmail(authorEmail);
         Acronym a = new Acronym(toSave[0]);
@@ -150,6 +146,6 @@ public class MessageHelper {
         Set<Explanation> set = new HashSet<>();
         set.add(e);
         a.setExplanations(set);
-        acronymExplanationDal.saveAcronym(a);
+        return acronymExplanationDal.saveAcronym(a);
     }
 }

--- a/src/main/java/com/redhat/persistence/AcronymExplanationDal.java
+++ b/src/main/java/com/redhat/persistence/AcronymExplanationDal.java
@@ -105,15 +105,14 @@ public class AcronymExplanationDal {
 
     private String getStackTraceAsString(Throwable e) {
         StringBuilder sb = new StringBuilder();
-        for (StackTraceElement element : e.getStackTrace()) {
-            sb.append(element.toString());
-            sb.append("\n");
-        }
+        sb.append(e.getMessage());
+        sb.append("\n");
 
         if(e.getCause() != null) {
-            sb.append("Caused by: \n");
+            sb.append("Caused by: ");
             sb.append(getStackTraceAsString(e.getCause()));
         }
+
         return sb.toString();
     }
 

--- a/src/main/java/com/redhat/persistence/AcronymExplanationDal.java
+++ b/src/main/java/com/redhat/persistence/AcronymExplanationDal.java
@@ -42,7 +42,7 @@ public class AcronymExplanationDal {
         } catch (Exception e) {
             e.printStackTrace();
             em.getTransaction().rollback();
-            return "Could not save the acronym: ```\n" + getStackTraceAsString(e) + "\n```";
+            return "Could not save the acronym: ```\n" + getStackTraceMaxSize(e, 4000) + "\n```";
         } finally {
             close();
         }
@@ -58,7 +58,7 @@ public class AcronymExplanationDal {
         } catch (Exception e) {
             e.printStackTrace();
             em.getTransaction().rollback();
-            return "Could not update the acronym: ```\n" + getStackTraceAsString(e) + "\n```";
+            return "Could not update the acronym: ```\n" + getStackTraceMaxSize(e, 4000) + "\n```";
         } finally {
             close();
         }
@@ -76,7 +76,7 @@ public class AcronymExplanationDal {
         } catch (Exception e) {
             e.printStackTrace();
             em.getTransaction().rollback();
-            return "Could not delete the acronym: ```\n" + getStackTraceAsString(e) + "\n```";
+            return "Could not delete the acronym: ```\n" + getStackTraceMaxSize(e, 4000) + "\n```";
         } finally {
             close();
         }
@@ -93,6 +93,16 @@ public class AcronymExplanationDal {
         this.em = null;
     }
 
+    private String getStackTraceMaxSize(Throwable e, int maxSize) {
+        String truncatedMsg = "\nThis stacktrace has been truncated...";
+        String stackTrace = getStackTraceAsString(e);
+        if(stackTrace.length() > maxSize) {
+            stackTrace = stackTrace.substring(0,maxSize - truncatedMsg.length());
+            stackTrace += truncatedMsg;
+        }
+        return stackTrace;
+    }
+
     private String getStackTraceAsString(Throwable e) {
         StringBuilder sb = new StringBuilder();
         for (StackTraceElement element : e.getStackTrace()) {
@@ -104,7 +114,6 @@ public class AcronymExplanationDal {
             sb.append("Caused by: \n");
             sb.append(getStackTraceAsString(e.getCause()));
         }
-
         return sb.toString();
     }
 

--- a/src/main/java/com/redhat/persistence/AcronymExplanationDal.java
+++ b/src/main/java/com/redhat/persistence/AcronymExplanationDal.java
@@ -1,5 +1,6 @@
 package com.redhat.persistence;
 
+import com.redhat.constants.Constants;
 import com.redhat.entities.Acronym;
 import com.redhat.entities.Explanation;
 
@@ -31,33 +32,39 @@ public class AcronymExplanationDal {
         }
     }
 
-    public void saveAcronym(Acronym acronym) {
+    public String saveAcronym(Acronym acronym) {
         init();
         em.getTransaction().begin();
         try {
            em.persist(acronym);
            em.getTransaction().commit();
+           return Constants.ACRONYM_SAVED;
         } catch (Exception e) {
             e.printStackTrace();
             em.getTransaction().rollback();
+            return "Could not save the acronym: ```\n" + getStackTraceAsString(e) + "\n```";
+        } finally {
+            close();
         }
-        close();
     }
 
-    public void updateAcronym(Acronym acronym) {
+    public String updateAcronym(Acronym acronym) {
         init();
         em.getTransaction().begin();
         try {
             em.merge(acronym);
             em.getTransaction().commit();
+            return Constants.ACRONYM_UPDATED;
         } catch (Exception e) {
             e.printStackTrace();
             em.getTransaction().rollback();
+            return "Could not update the acronym: ```\n" + getStackTraceAsString(e) + "\n```";
+        } finally {
+            close();
         }
-        close();
     }
 
-    public void deleteExplanation(Explanation explanation) {
+    public String deleteExplanation(Explanation explanation) {
         init();
         em.getTransaction().begin();
         try {
@@ -65,9 +72,13 @@ public class AcronymExplanationDal {
             explanation = em.merge(explanation);
             em.remove(explanation);
             em.getTransaction().commit();
+            return Constants.EXPLANATION_REMOVED;
         } catch (Exception e) {
             e.printStackTrace();
             em.getTransaction().rollback();
+            return "Could not delete the acronym: ```\n" + getStackTraceAsString(e) + "\n```";
+        } finally {
+            close();
         }
     }
 
@@ -80,6 +91,21 @@ public class AcronymExplanationDal {
     public void close() {
         em.close();
         this.em = null;
+    }
+
+    private String getStackTraceAsString(Throwable e) {
+        StringBuilder sb = new StringBuilder();
+        for (StackTraceElement element : e.getStackTrace()) {
+            sb.append(element.toString());
+            sb.append("\n");
+        }
+
+        if(e.getCause() != null) {
+            sb.append("Caused by: \n");
+            sb.append(getStackTraceAsString(e.getCause()));
+        }
+
+        return sb.toString();
     }
 
 }

--- a/src/test/java/com/redhat/MessageHelperTest.java
+++ b/src/test/java/com/redhat/MessageHelperTest.java
@@ -94,7 +94,7 @@ public class MessageHelperTest {
     public void updateDeleteTest() {
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.updateAcronymExplanationSameEmail()))
-                .isEqualTo(Constants.EXPLANATION_UPDATED);
+                .isEqualTo(Constants.ACRONYM_UPDATED);
         Assertions
                 .assertThat(helper.handleMessageAction(JsonNodeHelper.getInitialAcronymLowercase()))
                 .isEqualTo(JsonNodeHelper.EXPLANATION_UPDATE + "\n");

--- a/src/test/java/com/redhat/MessageHelperTest.java
+++ b/src/test/java/com/redhat/MessageHelperTest.java
@@ -174,6 +174,14 @@ public class MessageHelperTest {
                 .isEqualTo(JsonNodeHelper.EXPLANATION_UPDATE + "\n");
     }
 
+    @Test
+    public void exceptionPropagationTest() {
+        Assertions
+                .assertThat(helper.handleMessageAction(JsonNodeHelper.getDatabaseExceptionCausingMessage()))
+                .as("An acronym with explanation over 255 characters should return an exception to the user")
+                .contains("Value too long for column");
+    }
+
     @Before
     public void setupDB() {
         // Connecting will re-create all tables, and we insert an initial acronym for testing purposes

--- a/src/test/java/com/redhat/helpers/JsonNodeHelper.java
+++ b/src/test/java/com/redhat/helpers/JsonNodeHelper.java
@@ -118,6 +118,18 @@ public class JsonNodeHelper {
         return nodeHelpText;
     }
 
+    public static JsonNode getDatabaseExceptionCausingMessage() {
+        return alterArgumentText("!" + INITIAL_ACRONYM + "=" + getTooLongString());
+    }
+
+    private static String getTooLongString() {
+        StringBuilder sb = new StringBuilder();
+        while(sb.length() < 256) {
+            sb.append("AAAA AAAA AAAAAA AAAA AAAA AAAAA");
+        }
+        return sb.toString();
+    }
+
     private static String getJsonStringNoArgumentText() {
         return "{\n" +
                 "    \"type\": \"MESSAGE\",\n" +


### PR DESCRIPTION
This resolves issue #7. Requires testing on OpenShift, though automated tests pass.

Also, we should add an automated test to verify whether exception info is returned to the user.